### PR TITLE
Fix mobile compatibility: dictionary view won't load on mobile

### DIFF
--- a/src/ui/dictionary/dictionaryView.svelte
+++ b/src/ui/dictionary/dictionaryView.svelte
@@ -20,13 +20,13 @@
   let buttons: HTMLElement[] = [];
 
   onMount(() =>
-    setImmediate(() => {
+    setTimeout(() => {
       setIcon(buttons[0], "languages", 20);
       setIcon(buttons[1], "cloud", 20);
       setIcon(buttons[2], "bullet-list", 20);
       setIcon(buttons[3], "uppercase-lowercase-a", 20);
       setIcon(buttons[4], "documents", 20);
-    })
+    }, 0)
   );
 
   const debouncedSearch = debounce(search, 800, true);


### PR DESCRIPTION
On the mobile APP, it throws `ReferenceError: setImmediate is not defined` while loading.

As [pointed out by @krnlde](https://github.com/i18next/react-i18next/issues/787#issue-421028946), `setImmediate()` is a [non-standard feature ](https://developer.mozilla.org/en-US/docs/Web/API/Window/setImmediate) and should be avoid in production.