### PR TITLE
Show synonyms from FreeDictionaryAPI correctly

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,11 +1,11 @@
 {
-	"id": "obsidian-dictionary-plugin",
-	"name": "Dictionary",
-	"version": "2.22.0",
-	"minAppVersion": "0.12.11",
-	"description": "This is a simple dictionary for the Obsidian Note-Taking Tool.",
-	"author": "phibr0",
-	"authorUrl": "https://github.com/phibr0",
-	"isDesktopOnly": false,
-	"fundingUrl": "https://ko-fi.com/phibr0"
+  "id": "obsidian-dictionary-plugin",
+  "name": "Dictionary",
+  "version": "2.23.0",
+  "minAppVersion": "0.12.11",
+  "description": "This is a simple dictionary for the Obsidian Note-Taking Tool.",
+  "author": "phibr0",
+  "authorUrl": "https://github.com/phibr0",
+  "isDesktopOnly": false,
+  "fundingUrl": "https://ko-fi.com/phibr0"
 }

--- a/src/integrations/freeDictionaryAPI.ts
+++ b/src/integrations/freeDictionaryAPI.ts
@@ -101,6 +101,18 @@ export class FreeDictionarySynonymProvider extends Base implements SynonymProvid
         }
     }
 
+    uniqueSynonyms(synonyms: Synonym[]): Synonym[] {
+        const seen = {};
+        return synonyms.filter((synonym) => {
+            const k = `${synonym.word}${synonym.partsOfSpeech?.first()}`;
+            if (seen[k]) {
+                return false;
+            }
+            seen[k] = true;
+            return true;
+        });
+    }
+
     /**
      *
      * @param query - The word to look up synonyms for
@@ -120,7 +132,8 @@ export class FreeDictionarySynonymProvider extends Base implements SynonymProvid
             return Promise.reject("Word doesnt exist in this Dictionary");
         }
 
-        const meanings: Meaning[] = (await JSON.parse(result) as DictionaryWord[]).first().meanings;
+        const entry: DictionaryWord = (await JSON.parse(result) as DictionaryWord[]).first();
+        const meanings: Meaning[] = entry.meanings;
         const synonyms: Synonym[] = [];
 
         // The default POS provider seems pretty wonky at the moment,
@@ -134,6 +147,7 @@ export class FreeDictionarySynonymProvider extends Base implements SynonymProvid
                         def.synonyms.forEach(synonym => {
                             nonPOSMatch.push({
                                 word: synonym,
+                                partsOfSpeech: [meaning.partOfSpeech],
                             })
                         })
                     }
@@ -146,12 +160,21 @@ export class FreeDictionarySynonymProvider extends Base implements SynonymProvid
                     def.synonyms.forEach(synonym => {
                         synonyms.push({
                             word: synonym,
+                            partsOfSpeech: [meaning.partOfSpeech],
                         })
                     })
                 }
             })
+            if (meaning.synonyms) {
+                meaning.synonyms.forEach(synonym => {
+                    synonyms.push({
+                        word: synonym,
+                        partsOfSpeech: [meaning.partOfSpeech],
+                    });
+                })
+            }
         })
 
-        return synonyms.concat(nonPOSMatch);
+        return this.uniqueSynonyms(synonyms.concat(nonPOSMatch));
     }
 }

--- a/src/integrations/types.ts
+++ b/src/integrations/types.ts
@@ -32,6 +32,8 @@ export interface DictionaryWord {
 export interface Meaning {
     partOfSpeech: string;
     definitions: Definition[];
+    synonyms?: string[];
+    antonyms?: string[];
 }
 
 export interface Definition {

--- a/src/l10n/locale/en.ts
+++ b/src/l10n/locale/en.ts
@@ -90,6 +90,7 @@ export default {
     "Collapse Results": "Collapse Results",
     'Pronunciation': 'Pronunciation',
     'Meanings': 'Meanings',
+    "Thesaurus": "Thesaurus",
     "Origin": "Origin",
     'New Note': 'New Note',
     "View Error": "View Error",

--- a/src/ui/dictionary/dictionaryView.svelte
+++ b/src/ui/dictionary/dictionaryView.svelte
@@ -5,6 +5,7 @@
 
   import PhoneticComponent from "./phoneticComponent.svelte";
   import MeaningComponent from "./meaningComponent.svelte";
+  import ThesaurusComponent from "./thesaurusComponent.svelte";
   import ErrorComponent from "./errorComponent.svelte";
   import OriginComponent from "./originComponent.svelte";
   import t from "src/l10n/helpers";
@@ -171,6 +172,10 @@
           {#each data.meanings as { definitions, partOfSpeech }}
             <MeaningComponent word={data.word} {partOfSpeech} {definitions} />
           {/each}
+        </div>
+        <div class="container">
+          <h3>{t("Thesaurus")}</h3>
+          <ThesaurusComponent meanings={data.meanings}/>
         </div>
         {#if data.origin}
           <div class="container">

--- a/src/ui/dictionary/thesaurusComponent.svelte
+++ b/src/ui/dictionary/thesaurusComponent.svelte
@@ -1,0 +1,163 @@
+<script lang="ts">
+  import t from "src/l10n/helpers";
+  import type { Meaning } from "src/integrations/types";
+  import { Notice } from "obsidian";
+  import { slide } from "svelte/transition";
+  import { copy } from "obsidian-community-lib";
+
+  interface Entry {
+      partOfSpeech: string;
+      synonyms: Set;
+      antonyms: Set;
+      open: boolean;
+  }
+
+  export let meanings: Meaning[];
+
+  addEventListener("dictionary-collapse", (event: CustomEvent) => {
+    thesaurus.forEach((entry) => {
+      entry.open = event.detail.open as boolean;
+    })
+  });
+
+  function wordCopy(word: string) {
+copy(
+      word,
+      () =>
+        new Notice(
+          t('Copied "{{word}}" to clipboard').replace(/{{word}}/g, word)
+        ),
+      (error) => new Notice(error)
+    );
+  }
+
+  function groupByPOS(meanings: Meaning[]): Entry[] {
+    /* free dictionary API has synonyms and antonyms inside individual Meaning definitions
+     as well as at the top level. This helper groups them at the top level by their parts of speech.*/
+    let res: Entry[] = [];
+    meanings.forEach((meaning) => {
+        const m: Entry = {
+            open: false,
+            partOfSpeech: meaning.partOfSpeech,
+            synonyms: new Set(meaning.synonyms),
+            antonyms: new Set(meaning.antonyms),
+        };
+        meaning.definitions.forEach((definition) => {
+            definition.synonyms.forEach((synonym) => {
+                synonyms.add(synonym);
+            });
+            definition.antonyms.forEach((antonym) => {
+                antonyms.add(antonym)
+            });
+        });
+        if (m.synonyms.size > 0 || m.antonyms.size > 0) {
+            res.push(m);
+        }
+    });
+    return res;
+  }
+  const thesaurus = groupByPOS(meanings);
+</script>
+
+<div class="main">
+  {#each thesaurus as entry, i}
+    <div class="opener" class:open={entry.open} on:click={() => (entry.open = !entry.open)}>
+      <div class="tree-item-icon collapse-icon" style="">
+        <svg viewBox="0 0 100 100" class="right-triangle" width="8" height="8">
+          <path
+            fill="currentColor"
+            stroke="currentColor"
+            d="M94.9,20.8c-1.4-2.5-4.1-4.1-7.1-4.1H12.2c-3,0-5.7,1.6-7.1,4.1c-1.3,2.4-1.2,5.2,0.2,7.6L43.1,88c1.5,2.3,4,3.7,6.9,3.7 s5.4-1.4,6.9-3.7l37.8-59.6C96.1,26,96.2,23.2,94.9,20.8L94.9,20.8z"
+          />
+        </svg>
+      </div>
+      {entry.partOfSpeech}
+    </div>
+    {#if entry.open}
+      <div transition:slide|local={{ duration: 150 }}>
+        {#if entry.synonyms.size > 0}
+          <div class="synonyms">
+            <div class="label">{t("Synonyms:")}</div>
+            <p>
+              {#each [...entry.synonyms] as synonym, j}
+                <span class="synonym" on:click={() => wordCopy(synonym)}>{synonym}</span
+                >{#if j < entry.synonyms.size - 1}{", "}{/if}
+              {/each}
+            </p>
+          </div>
+        {/if}
+        {#if entry.antonyms.size > 0}
+          <div class="antonyms">
+            <div class="label">{t("Antonyms:")}</div>
+            <p>
+              {#each [...entry.antonyms] as antonym, j}
+                <span class="antonym" on:click={() => wordCopy(antonym)}>{antonym}</span
+                >{#if j < entry.antonyms.size - 1}{", "}{/if}
+              {/each}
+            </p>
+          </div>
+        {/if}
+      </div>
+    {/if}
+  {/each}
+</div>
+
+<style lang="scss">
+  .opener {
+    display: flex;
+    .collapse-icon::after {
+      content: "\00a0";
+    }
+    svg {
+      transform: rotate(-90deg);
+    }
+    &.open svg {
+      transform: rotate(0);
+    }
+  }
+  .antonym,
+  .synonym {
+    transition: 100ms;
+    &:hover {
+      color: var(--interactive-accent);
+      border-radius: 2px;
+    }
+  }
+
+  .main {
+    background-color: var(--background-secondary);
+    padding-left: 0.6rem;
+    padding-right: 0.6rem;
+    padding-top: 0.3rem;
+    padding-bottom: 0.3rem;
+    margin-bottom: 0.3rem;
+    border-radius: 0.3rem;
+
+    blockquote {
+      font-style: italic;
+      margin: 0 0 1rem;
+      padding-left: 1rem;
+      border-left: 1px solid var(--background-modifier-border);
+    }
+
+    :global(.mark) {
+      box-shadow: inset 0 -2px var(--text-faint);
+    }
+  }
+
+  .label {
+    font-size: 0.875em;
+    font-weight: bold;
+  }
+
+  .antonyms,
+  .synonyms {
+    padding-top: 1rem;
+  }
+
+  .antonyms > p,
+  .synonyms > p {
+    margin-top: 0;
+  }
+
+</style>


### PR DESCRIPTION
#98 

Fixes the the synonym popover to also pull in synonyms from the top-level `meaning` object rather than only the `definition` entries

<img width="277" alt="Screenshot 2025-02-11 at 2 34 17 PM" src="https://github.com/user-attachments/assets/d2d12b53-7334-4fd2-b470-55d8272a5528" />

Adds new `Thesaurus` section to `DefinitionView` for showing synonyms and antonyms

<img width="320" alt="Screenshot 2025-02-11 at 2 32 06 PM" src="https://github.com/user-attachments/assets/9f90627f-3f34-4d6c-8bb6-cc2439aa884d" />
